### PR TITLE
Fix import from Tupperbox regression defect (#137)

### DIFF
--- a/PluralKit.Core/DataFiles.cs
+++ b/PluralKit.Core/DataFiles.cs
@@ -263,7 +263,7 @@ namespace PluralKit.Bot
             {
                 Members = Tuppers.Select(t => t.ToPluralKit(ref lastSetTag, ref output.HadMultibrackets,
                     ref output.HadGroups, ref output.HadMultibrackets)).ToList(),
-                
+                Switches = new List<DataFileSwitch>(),
                 // If we haven't had multiple tags set, use the last (and only) one we set as the system tag
                 Tag = !output.HadIndividualTags ? lastSetTag : null
             };
@@ -303,6 +303,7 @@ namespace PluralKit.Bot
 
             return new DataFileMember
             {
+                Id = Guid.NewGuid().ToString(), // Note: this is only ever used for lookup purposes
                 Name = Name,
                 AvatarUrl = AvatarUrl,
                 Birthday = Birthday,


### PR DESCRIPTION
* Fix bulk importer parameter and remove unused method

-Fixes AddSwitchesBulk post-refactor by passing in the switch timestamp instead of a set of PKMembers
-Removes unused RegisterSwitches method which was replaced by AddSwitchesBulk

* Fix import from Tupperbox regression defect

When converting a Tupperbox import file to the PluralKit format on import, this sets the Tupper's name as the member ID which seems like a reasonable default. I'm also initializing the switches collection (even though it's going to be empty in this case).

This fixes a regression defect introduced when switch import was implemented.

* Making converted Tupper DataFileMember Id a GUID instead

Member names aren't necessarily unique (even if they should be), and no reason not to use something we know will be unique...